### PR TITLE
Check connection race condition (goroutine leak, panic) and ping/pong problem

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -6,10 +6,16 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+type writingMessage struct {
+	messageType int
+	data        []byte
+}
 
 /*
 WebsocketClient - client that listens for events and sends actions to Websocket server
@@ -19,6 +25,9 @@ type WebsocketClient struct {
 	Conn         *websocket.Conn
 	dataHandler  func(interface{})
 	errorHandler func(interface{})
+	writeChan    chan writingMessage
+	writeErrChan chan error
+	initData     sync.Once
 }
 
 /*
@@ -50,6 +59,16 @@ func (ws *WebsocketClient) Connect() error {
 	if err != nil {
 		return err
 	}
+	ws.initData.Do(func() {
+		ws.writeChan = make(chan writingMessage)
+		ws.writeErrChan = make(chan error)
+		go func() {
+			for {
+				message := <-ws.writeChan
+				ws.writeErrChan <- ws.Conn.WriteMessage(message.messageType, message.data)
+			}
+		}()
+	})
 	log.Println("[WS] Connected to server")
 	return nil
 }
@@ -61,14 +80,14 @@ func (ws *WebsocketClient) Listen() {
 	if ws.Conn == nil {
 		ws.Connect()
 	}
-	pongWait := 5 * time.Second
-	ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
+	checkConnDone := make(chan struct{})
 	ws.Conn.SetPongHandler(func(string) error {
-		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
+		ws.Conn.SetReadDeadline(time.Time{})
 		return nil
 	})
-	go ws.checkConnection()
-	go func() {
+	go ws.checkConnection(checkConnDone)
+	go func(checkConnDone chan<- struct{}) {
+		defer close(checkConnDone)
 		defer ws.Conn.Close()
 		for {
 			var message interface{}
@@ -82,19 +101,36 @@ func (ws *WebsocketClient) Listen() {
 			}
 			go ws.handleData(message)
 		}
-	}()
+	}(checkConnDone)
 }
 
-func (ws *WebsocketClient) checkConnection() {
+func (ws *WebsocketClient) checkConnection(done <-chan struct{}) {
+	var timer *time.Timer
+	pingInterval := 10 * time.Second
+	pongWait := 9 * time.Second // less than pingInterval
 	for {
-		defer ws.Conn.Close()
-		err := ws.Conn.WriteMessage(websocket.PingMessage, []byte("PING"))
-		if err != nil {
-			log.Println("[ERROR][WS] Sending ping: ", err)
+		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
+		if err := ws.writeMessage(websocket.PingMessage, []byte("PING")); err != nil {
+			ws.Conn.SetReadDeadline(time.Time{})
+			log.Println("[ERROR][WS] Sending ping:", err)
 			return
 		}
-		time.Sleep(5 * time.Second)
+		if timer == nil {
+			timer = time.NewTimer(pingInterval)
+		}
+		select {
+		case <-done:
+			return
+		case <-timer.C:
+			timer.Reset(pingInterval)
+		}
 	}
+}
+
+func (ws *WebsocketClient) writeMessage(messageType int, data []byte) error {
+	ws.writeChan <- writingMessage{messageType: messageType, data: data}
+	err := <-ws.writeErrChan
+	return err
 }
 
 func (ws *WebsocketClient) handleData(data interface{}) {
@@ -117,7 +153,7 @@ func (ws *WebsocketClient) Send(data interface{}) error {
 	if err != nil {
 		return err
 	}
-	return ws.Conn.WriteMessage(websocket.TextMessage, req)
+	return ws.writeMessage(websocket.TextMessage, req)
 }
 
 func (ws *WebsocketClient) getAddress() string {
@@ -130,7 +166,7 @@ Close - closing connection
 func (ws *WebsocketClient) Close() error {
 	fmt.Println("[WS][CLIENT] Closing connection")
 	if ws.Conn != nil {
-		return ws.Conn.WriteMessage(
+		return ws.writeMessage(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		)

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -55,10 +55,10 @@ func (ws *WebsocketClient) Connect() error {
 	log.Printf("[INFO] Connecting to %s", url)
 
 	c, _, err := websocket.DefaultDialer.Dial(url, nil)
-	ws.Conn = c
 	if err != nil {
 		return err
 	}
+	ws.Conn = c // c is nil if error. Do not move above because of concurrent goroutines.
 	ws.initData.Do(func() {
 		ws.writeChan = make(chan writingMessage)
 		ws.writeErrChan = make(chan error)


### PR DESCRIPTION
Fixed:
1. Goroutine leaks.
2. Panic while concurrent writing.
3. Changed ping/pong control. Measure ping/pong interval instead of pong/pong one.
4. Increased ping/pong interval to 9 seconds. The interval was equal to 8.097564857s at 2018-06-22 13:58:41.320568127 +0300 MSK in Cybo project (to Naga).
5. While reconnect error: "panic: runtime error: invalid memory address or nil pointer dereference".
